### PR TITLE
feat: tighten fire hazard hitbox

### DIFF
--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -443,6 +443,10 @@ export default class Demo extends Phaser.Scene {
       newObj.anims.play('burning');
       // add to the group
       this.fires.add(newObj);
+
+      // Keep the danger close to the visible flame so edge grazes feel fair.
+      newObj.body.setSize(12, 12);
+      newObj.body.setOffset(4, 8);
     }
   }
 


### PR DESCRIPTION
## What
Tighten the fire hazard collision box so the danger matches the visible flame more closely.

## Why
The previous overlap used the full sprite rectangle, which can cause "cheap" deaths on edge grazes.

## Notes
- No gameplay rules changed; this only improves collision fairness.
- `yarn build` passes.
